### PR TITLE
feat: implement command line arguments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can also right click a single image and only optimize that one.
 ```js
 {
   "optimizeImages.app": "", // Name of the app to use for optimizating the images
+  "optimizeImages.appOptions": [], // An array of options to be passed to the app on execution. You can use the array item "[filepath]" as a placeholder for the filepath to the currently processed file
   "optimizeImages.imageRegex": ".*\\.(png|gif|jpe?g)$", // Regex used for matching images. Requires double escaping
   "optimizeImages.searchDepth": 10, // Maximum depth to look at when searching images
   "optimizeImages.searchStartingPath": ".", // Path relative to the root where to start searching images

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
           "description": "Name of the app to use for optimizating the images",
           "default": ""
         },
+        "optimizeImages.appOptions": {
+          "type": "array",
+          "description": "An array of options to be passed to the app on execution.\nUse the placeholder '[filepath]' (without quotes) to insert the filepath to the currently processed file",
+          "default": []
+        },
         "optimizeImages.imageRegex": {
           "type": "string",
           "description": "Regex used for matching images",
@@ -134,8 +139,7 @@
   "dependencies": {
     "@types/node": "^10.12.8",
     "lodash": "^4.17.4",
-    "open": "0.0.5",
-    "pify": "^3.0.0",
+    "opn": "^5.4.0",
     "walker": "^1.0.7"
   },
   "devDependencies": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,9 +2,8 @@
 /* IMPORT */
 
 import * as _ from 'lodash';
-import * as openPath from 'open';
+import * as opn from 'opn';
 import * as path from 'path';
-import * as pify from 'pify';
 import * as vscode from 'vscode';
 import * as walker from 'walker';
 import Config from './config';
@@ -72,18 +71,39 @@ function optimizeFile ( file ) {
 async function optimizePaths ( paths ) {
 
   const config = Config.get ();
+  const placeholderId = config.appOptions.indexOf( '[filepath]' );
 
   paths = _.castArray ( paths );
 
   if ( config.app ) {
 
-    const open = pify ( openPath );
-
     for ( let path of paths ) {
 
-      await open ( path, config.app );
+      const input = placeholderId === -1 ? path : '';
+      const options = [ ...config.appOptions ];
 
+      if ( placeholderId > -1 ) {
+
+        options.splice( placeholderId, 1, path );
+
+      }
+
+      try {
+
+        await opn( input, { app: [ config.app, ...options ] } ).then( cp => {
+
+          console.log( `[fabiospampinato.vscode-optimize-images] File processed: ${path}; Exit code: ${cp.exitCode}` );
+
+        } );
+
+      } catch ( err ) {
+
+        vscode.window.showErrorMessage( 'Error while processing file: ' + path );
+
+      }
     }
+
+    vscode.window.showInformationMessage( 'Image optimization complete' );
 
   } else {
 


### PR DESCRIPTION
Hi Fabio,

Finally got around to it.
Here is the mentioned pull request.
I have replaced `pify` and `open` with `opn`.

I looked into the differences between `open` and `opn` and in theory it should be working as before.
The difference is that `open` spawns a new shell to execute the command.
Please verify that it works still the same way as before with ImageOptim.

Also I adopted the configuration syntax as first suggested by you ('[filepath]' as separate array item).

I have looked into `imagemin` and I would suggest basing the implementation on [this guide](https://images.guide/) by Addy Osmani.

I will use issue #3 to post my suggestions on how to proceed (tomorrow evening).